### PR TITLE
Protect fresh manifests

### DIFF
--- a/cmd/nscgc/main.go
+++ b/cmd/nscgc/main.go
@@ -93,7 +93,7 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("failed to make registry: %w", err)
 	}
 
-	olderThan := time.Now().UTC().Add(-3 * 24 * time.Hour)
+	olderThan := time.Now().UTC().Add(-7 * 24 * time.Hour)
 	deleteManifests := false
 
 	if dropManifestsOlderThan != nil && *dropManifestsOlderThan != "" {


### PR DESCRIPTION
- protect manifests if not in exhaustive needed set but newer than "OlderThan".
- change default of "OlderThan" to 7 days to be more cautious.
- simplify code structure a bit
- improve output in tag chains